### PR TITLE
Rudimentary Linux Support.

### DIFF
--- a/InsaneLimits.cs
+++ b/InsaneLimits.cs
@@ -3613,7 +3613,7 @@ namespace PRoConEvents
             String procon_path = Directory.GetParent(Application.ExecutablePath).FullName;
             String plugins_path = Path.Combine(procon_path, Path.Combine("Plugins", "BF3"));
 
-            // 
+            // fixes compilation issues on Linux under mono
             if(IsRunningOnLinux()) {
                 plugins_path = Directory.GetParent(Assembly.GetExecutingAssembly().Location).FullName;
             }


### PR DESCRIPTION
This patch adds a couple of hacks to enable Insane Limits to be run on Linux using Mono. Currently some manual intervention is needed to get it working right (such as requiring the user to re-agree to the privacy policy on PRoCon restart, and (at least on the first run) requiring the user to add a `/` to the start of the path in the `limits_file` property in PRoCon and restore their limits' `.conf` configurations as it may overwrite them (only on the first run)). However it does enable the plugin to save settings and compile Limits.

Tested on a vanilla (no other plugins) PRoCon setup with Ubuntu 12.04 x86 with Mono 2.10.8.1.
EDIT: Seems to play well with other plugins as well.

```
Mono JIT compiler version 2.10.8.1 (Debian 2.10.8.1-1ubuntu2.2)
Copyright (C) 2002-2011 Novell, Inc, Xamarin, Inc and Contributors. www.mono-project.com
        TLS:           __thread
        SIGSEGV:       altstack
        Notifications: epoll
        Architecture:  x86
        Disabled:      none
        Misc:          softdebug
        LLVM:          supported, not enabled.
        GC:            Included Boehm (with typed GC and Parallel Mark)
```
